### PR TITLE
Feat/push env vars

### DIFF
--- a/cmd/commands/commands/maintenance/commands/common/command.go
+++ b/cmd/commands/commands/maintenance/commands/common/command.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-
 	cnappgoat "github.com/ermetic-research/CNAPPgoat"
 	"github.com/ermetic-research/CNAPPgoat/cmd/commands/common"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"

--- a/cmd/commands/commands/maintenance/commands/common/command.go
+++ b/cmd/commands/commands/maintenance/commands/common/command.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	
 	cnappgoat "github.com/ermetic-research/CNAPPgoat"
 	"github.com/ermetic-research/CNAPPgoat/cmd/commands/common"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"

--- a/engine.go
+++ b/engine.go
@@ -393,24 +393,40 @@ func environToMap() (map[string]string, error) {
 	return envMap, nil
 }
 func (e *Engine) setStackConfigurationFromGlobalSettings(ctx context.Context, scenario *Scenario, s auto.Stack) error {
-	if project := getValueFromEnvOrGcloudConfig("core/project", "GOOGLE_PROJECT", "GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT", "CLOUDSDK_CORE_PROJECT"); project != "" {
-		if err := s.SetConfig(ctx, "gcp:project", auto.ConfigValue{Value: project}); err != nil {
-			return e.writeErrorState(scenario, err, "failed to set config")
+	if scenario.ScenarioParams.Platform == GCP {
+		if _, err := exec.LookPath("gcloud"); err != nil {
+			return e.writeErrorState(scenario, err, "Google Cloud CLI is not installed or configured correctly")
+		}
+		if project := getValueFromEnvOrGcloudConfig("core/project", "GOOGLE_PROJECT", "GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT", "CLOUDSDK_CORE_PROJECT"); project != "" {
+			if err := s.SetConfig(ctx, "gcp:project", auto.ConfigValue{Value: project}); err != nil {
+				return e.writeErrorState(scenario, err, "failed to set config")
+			}
+		}
+
+		if region := getValueFromEnvOrGcloudConfig("compute/region", "GOOGLE_REGION", "GCLOUD_REGION", "CLOUDSDK_COMPUTE_REGION"); region != "" {
+			if err := s.SetConfig(ctx, "gcp:region", auto.ConfigValue{Value: region}); err != nil {
+				return e.writeErrorState(scenario, err, "failed to set config")
+			}
+		}
+
+		if zone := getValueFromEnvOrGcloudConfig("compute/zone", "GOOGLE_ZONE", "GCLOUD_ZONE", "CLOUDSDK_COMPUTE_ZONE"); zone != "" {
+			if err := s.SetConfig(ctx, "gcp:zone", auto.ConfigValue{Value: zone}); err != nil {
+				return e.writeErrorState(scenario, err, "failed to set config")
+			}
 		}
 	}
 
-	if region := getValueFromEnvOrGcloudConfig("compute/region", "GOOGLE_REGION", "GCLOUD_REGION", "CLOUDSDK_COMPUTE_REGION"); region != "" {
-		if err := s.SetConfig(ctx, "gcp:region", auto.ConfigValue{Value: region}); err != nil {
-			return e.writeErrorState(scenario, err, "failed to set config")
+	if scenario.ScenarioParams.Platform == AWS {
+		if _, err := exec.LookPath("aws"); err != nil {
+			return e.writeErrorState(scenario, err, "AWS CLI is not installed or configured correctly")
 		}
 	}
 
-	if zone := getValueFromEnvOrGcloudConfig("compute/zone", "GOOGLE_ZONE", "GCLOUD_ZONE", "CLOUDSDK_COMPUTE_ZONE"); zone != "" {
-		if err := s.SetConfig(ctx, "gcp:zone", auto.ConfigValue{Value: zone}); err != nil {
-			return e.writeErrorState(scenario, err, "failed to set config")
+	if scenario.ScenarioParams.Platform == Azure {
+		if _, err := exec.LookPath("az"); err != nil {
+			return e.writeErrorState(scenario, err, "Azure CLI is not installed or configured correctly")
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
Enhance environment variable handling and workspace initialization
- Introduced `environToMap` function to convert OS environment variables to a map.
- Improved error handling for invalid environment variable formats.
- Push these env vars into the child workspaces

Enhance configuration management with environment and gcloud fallbacks 
- Add `getValueFromEnvOrGcloudConfig` to prioritize environment variables over gcloud config values.
- Extend `Engine` with `setStackConfigurationFromGlobalSettings` to set Pulumi stack configurations based on global settings, considering both environment variables and gcloud configurations.
- Add utility functions `getGcloudValue` and `getEnv` to fetch values from gcloud and environment respectively.